### PR TITLE
Issue 30 -- failing unittests from PR 28

### DIFF
--- a/test/libpython_clj/require_python_test.clj
+++ b/test/libpython_clj/require_python_test.clj
@@ -74,9 +74,6 @@
     ;; no exclusions
     (is (= #{} exclude))
     (is (= #{:no-arglists :reload} supported-flags))
-    (is (= 'libpython-clj.require-python-test
-           current-ns-sym
-           (symbol (str current-ns))))
     (is (= 'csv module-name module-name-or-ns))
     (is (nil? reload?))
     (is (nil? no-arglists?))
@@ -109,9 +106,6 @@
     ;; no exclusions
     (is (= #{} exclude))
     (is (= #{:no-arglists :reload} supported-flags))
-    (is (= 'libpython-clj.require-python-test
-           current-ns-sym
-           (symbol (str  current-ns))))
     (is (= 'requests module-name module-name-or-ns))
     (is (= reload? :reload))
     (is (= no-arglists? :no-arglists))


### PR DESCRIPTION
Closes: https://github.com/cnuernber/libpython-clj/issues/30

Removing these tests as they are non-deterministic (depending on how test runner is invoked).  Can reinstate a similar test once we agree on testing framework.  