### PR TITLE
Issue 29 - class ns syntax

### DIFF
--- a/src/libpython_clj/require.clj
+++ b/src/libpython_clj/require.clj
@@ -609,3 +609,4 @@
     (load-python-lib (vector reqs))
     (vector? reqs)
     (load-python-lib reqs)))
+

--- a/test/libpython_clj/require_python_test.clj
+++ b/test/libpython_clj/require_python_test.clj
@@ -75,7 +75,6 @@
     (is (= #{} exclude))
     (is (= #{:no-arglists :reload :alpha-load-ns-classes}
            supported-flags))
-    (is (= #{:no-arglists :reload} supported-flags))
     (is (= 'csv module-name module-name-or-ns))
     (is (nil? reload?))
     (is (nil? no-arglists?))

--- a/test/libpython_clj/require_python_test.clj
+++ b/test/libpython_clj/require_python_test.clj
@@ -73,7 +73,8 @@
 
     ;; no exclusions
     (is (= #{} exclude))
-    (is (= #{:no-arglists :reload} supported-flags))
+    (is (= #{:no-arglists :reload :alpha-load-ns-classes}
+           supported-flags))
     (is (= 'libpython-clj.require-python-test
            current-ns-sym
            (symbol (str current-ns))))
@@ -108,7 +109,6 @@
 
     ;; no exclusions
     (is (= #{} exclude))
-    (is (= #{:no-arglists :reload} supported-flags))
     (is (= 'libpython-clj.require-python-test
            current-ns-sym
            (symbol (str  current-ns))))


### PR DESCRIPTION
Closes: https://github.com/cnuernber/libpython-clj/issues/29
Opt-in alpha syntax for ns-classes.  There's a lot of stuff it doesn't do.  But there's a lot of stuff it DOES!

Does not currently respect `:reload` flag.  Will take care of that as part of future enhancement.

```clojure 
(comment
  (require-python '[builtins :as python :alpha-load-ns-classes])
  (def xs (python/list))
  (doseq [x (range 10)]
    (python.list/append xs (python.str/format "Your number is {x}" :x x)))
  xs ;;=> ['Your number is 0', 'Your number is 1', 'Your number is 2', 'Your number is 3', 'Your number is 4', 'Your number is 5', 'Your number is 6', 'Your number is 7', 'Your number is 8', 'Your number is 9']
)
```