### PR TITLE
Issue-35a: (require-python 'module.class) and '[module.class :as module-alias.class-alias]

### DIFF
--- a/src/libpython_clj/require.clj
+++ b/src/libpython_clj/require.clj
@@ -55,9 +55,12 @@
 
 (def ^:private pymodule? (py/get-attr inspect "ismodule"))
 
-(def ^:private findspec (-> importlib
-                            (py/get-attr "util")
-                            (py/get-attr "find_spec")))
+(defn ^:private findspec [x]
+  (let [-findspec
+        (-> importlib
+            (py/get-attr "util")
+            (py/get-attr "find_spec"))]
+    (-findspec x)))
 
 (def ^:private hasattr (py/get-attr builtins "hasattr"))
 

--- a/src/libpython_clj/require.clj
+++ b/src/libpython_clj/require.clj
@@ -42,6 +42,8 @@
 
 (def ^:private importlib (py/import-module "importlib"))
 
+(def ^:private importlib_util (py/import-module "importlib.util"))
+
 (def ^:private reload-module (py/get-attr importlib "reload"))
 
 (def ^:priviate import-module (py/get-attr importlib "import_module"))
@@ -57,9 +59,7 @@
 
 (defn ^:private findspec [x]
   (let [-findspec
-        (-> importlib
-            (py/get-attr "util")
-            (py/get-attr "find_spec"))]
+        (-> importlib_util (py/get-attr "find_spec"))]
     (-findspec x)))
 
 (def ^:private hasattr (py/get-attr builtins "hasattr"))

--- a/test/libpython_clj/require_python_test.clj
+++ b/test/libpython_clj/require_python_test.clj
@@ -112,3 +112,35 @@
     (is (= requests-module this-module))
     (is (= #{'get} refer))
     (is (nil? python-namespace))))
+
+
+(require-python '([builtins :as python]
+                  [builtins.list :as python.pylist]))
+
+;; NOTE -- even though builtins.list has been aliased to
+;; to python.pylist, you are still required to require
+;; "builtins as python" in order to construct a list
+
+(deftest require-python-classes-with-alias-test
+  (let [l (python/list)]
+    (is (= (vec l) []))
+    (python.pylist/append l 1)
+    (is (= (vec l) [1]))
+    (python.pylist/append l 3)
+    (is (= (vec l) [1 3]))
+    (python.pylist/append l 5)
+    (is (= (vec l) [1 3 5]))
+    (is (= python.pylist/append python.list/append))
+    (python.pylist/clear l)
+    (is (= (python/list) (vec l)))))
+
+
+(require-python 'csv.DictWriter)
+
+(deftest require-python-classes
+  ;; simple creation/recall test
+  (is csv.DictWriter/__init__)
+  (is csv.DictWriter/writeheader)
+  (is csv.DictWriter/writerow)
+  (is csv.DictWriter/writerows))
+


### PR DESCRIPTION
This PR adds support for 
```clojure 
(require-python '[builtins.list :as python.pylist])
``` 
and 
```clojure 
(require-python 'csv.DictWriter)
```
style requirement invocations as referenced in https://github.com/cnuernber/libpython-clj/issues/35.

Additionally `:alpha-load-ns-classes` is now always true by default.  We could add opt-out support if there was a reason.