### PR TITLE
Python gc in python thread

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,7 @@
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [camel-snake-kebab "0.4.0"]
                  [techascent/tech.datatype "4.69"]
+                 [techascent/tech.resource "4.6-SNAPSHOT"]
                  [org.clojure/data.json "0.2.7"]]
   :repl-options {:init-ns user}
   :java-source-paths ["java"])

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
             :url "https://www.eclipse.org/legal/epl-2.0/"}
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [camel-snake-kebab "0.4.0"]
-                 [techascent/tech.datatype "4.69"]
-                 [techascent/tech.resource "4.6-SNAPSHOT"]
+                 [techascent/tech.datatype "4.70"]
                  [org.clojure/data.json "0.2.7"]]
   :repl-options {:init-ns user}
   :java-source-paths ["java"])

--- a/src/libpython_clj/python/gc.clj
+++ b/src/libpython_clj/python/gc.clj
@@ -31,7 +31,9 @@
                                                        (.remove (ptr-set) ptr-val)
                                                        (dispose-fn)))
         ^ConcurrentLinkedDeque stack-context (stack-context)]
-
+    ;;We have to keep track of the pointer.  If we do not the pointer gets gc'd then
+    ;;it will not be put on the reference queue when the object itself is gc'd.
+    ;;Nice little gotcha there.
     (if stack-context
       (.add stack-context ptr-val)
       ;;Ensure we don't lose track of the weak reference.  If it gets cleaned up

--- a/src/libpython_clj/python/gc.clj
+++ b/src/libpython_clj/python/gc.clj
@@ -1,0 +1,66 @@
+(ns libpython-clj.python.gc
+  "Binding of various sort of gc semantics optimized specifically for
+  libpython-clj.  For general bindings, see tech.resource"
+  (:import [java.util.concurrent ConcurrentHashMap ConcurrentLinkedDeque]
+           [java.lang.ref ReferenceQueue]
+           [tech.resource GCReference]))
+
+
+(set! *warn-on-reflection* true)
+
+
+(defonce ^:dynamic *stack-gc-context* nil)
+(defn stack-context
+  ^ConcurrentLinkedDeque []
+  *stack-gc-context*)
+
+(defonce reference-queue-var (ReferenceQueue.))
+(defn reference-queue
+  ^ReferenceQueue []
+  reference-queue-var)
+
+(defonce ptr-set-var (ConcurrentHashMap/newKeySet))
+(defn ptr-set
+  ^java.util.Set []
+  ptr-set-var)
+
+
+(defn track
+  [item dispose-fn]
+  (let [ptr-val (GCReference. item (reference-queue) (fn [ptr-val]
+                                                       (.remove (ptr-set) ptr-val)
+                                                       (dispose-fn)))
+        ^ConcurrentLinkedDeque stack-context (stack-context)]
+
+    (if stack-context
+      (.add stack-context ptr-val)
+      ;;Ensure we don't lose track of the weak reference.  If it gets cleaned up
+      ;;the gc system will fail.
+      (.add (ptr-set) ptr-val))
+    item))
+
+
+(defn clear-reference-queue
+  []
+  (when-let [next-ref (.poll (reference-queue))]
+    (.run ^Runnable next-ref)
+    (recur)))
+
+
+(defn clear-stack-context
+  []
+  (let [^java.util.Iterator iter (.descendingIterator (stack-context))]
+    (loop [continue? (.hasNext iter)]
+      (when continue?
+        (let [next-val (.next iter)]
+          (.run ^Runnable next-val))
+        (recur (.hasNext iter))))))
+
+
+(defmacro with-stack-context
+  [& body]
+  `(with-bindings {#'*stack-gc-context* (ConcurrentLinkedDeque.)}
+     (try
+       ~@body
+       (finally
+         (clear-stack-context)))))

--- a/src/libpython_clj/python/gc.clj
+++ b/src/libpython_clj/python/gc.clj
@@ -14,10 +14,12 @@
   ^ConcurrentLinkedDeque []
   *stack-gc-context*)
 
+
 (defonce reference-queue-var (ReferenceQueue.))
 (defn reference-queue
   ^ReferenceQueue []
   reference-queue-var)
+
 
 (defonce ptr-set-var (ConcurrentHashMap/newKeySet))
 (defn ptr-set
@@ -51,12 +53,9 @@
 
 (defn clear-stack-context
   []
-  (let [^java.util.Iterator iter (.descendingIterator (stack-context))]
-    (loop [continue? (.hasNext iter)]
-      (when continue?
-        (let [next-val (.next iter)]
-          (.run ^Runnable next-val))
-        (recur (.hasNext iter))))))
+  (when-let [next-ref (.pollLast (stack-context))]
+    (.run ^Runnable next-ref)
+    (recur)))
 
 
 (defmacro with-stack-context

--- a/src/libpython_clj/python/interpreter.clj
+++ b/src/libpython_clj/python/interpreter.clj
@@ -1,7 +1,7 @@
 (ns libpython-clj.python.interpreter
   (:require [libpython-clj.jna :as libpy ]
             [libpython-clj.jna.base :as libpy-base]
-            [tech.resource :as resource]
+            [libpython-clj.python.gc :as pygc]
             [libpython-clj.python.logging
              :refer [log-error log-warn log-info]]
             [tech.jna :as jna]
@@ -348,6 +348,7 @@ print(json.dumps(
            (try
              ~@body
              (finally
+               (pygc/clear-reference-queue)
                (when new-binding?#
                  (release-gil! interp#)))))))))
 
@@ -433,7 +434,7 @@ print(json.dumps(
           (recur library-names))))
     ;;Set program name
     (when-let [program-name (or program-name *program-name* "")]
-      (resource/stack-resource-context
+      (pygc/with-stack-context
        (libpy/PySys_SetArgv 0 (-> program-name
                                   (jna/string->wide-ptr)))))
     (let [type-symbols (libpy/lookup-type-symbols)

--- a/test/libpython_clj/stress_test.clj
+++ b/test/libpython_clj/stress_test.clj
@@ -56,10 +56,6 @@ def getmultidata():
     (gd-fn)))
 
 
-;;If you want to see how the sausage is made...
-(alter-var-root #'libpython-clj.python.object/*object-reference-logging*
-                (constantly false))
-
 ;;Ensure that failure to open resource context before tracking for stack
 ;;related things causes immediate failure.  Unless you feel like being pedantic,
 ;;this isn't necessary.  The python library automatically switches to normal gc-only


### PR DESCRIPTION
This PR makes python access single threaded in the case where your require also happens in one thread.  The gc queue is now cooperatively cleared upon exit of `with-gil`.  This also means that the cleanup can keep the gil in one move and batch all cleanups.

This solves https://github.com/cnuernber/libpython-clj/issues/48.