### PR TITLE
ISSUE-60: Add support for prefix lists and fix require-python/require syntax conformity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 ## 1.33-SNAPSHOT
 
+* **BREAKING CHANGE** `require-python` now respects prefix lists --
+  unfortunately, the previous syntax was incorrect. 
+  ```clojure 
+  ;; WRONG (syntax version < 1.33)
+  (require-python '(os math)) 
+  ```
+  would be equivalent to 
+  ```clojure 
+  ;; (do (require-python 'os) (require-python 'math))
+  ```
+  the correct syntax for this SHOULD have been
+  ```clojure 
+  (require-python 'os 'math)
+  ```
+  
+  1.33 fixes this mistake, and provides support for prefix lists, 
+  for example:
+  
+  ```clojure
+  (require-python 
+   '[builtins :as python]
+   '(builtins 
+     [list :as python.list]
+     [dict :as python.dict]
+     [tuple :as python.tuple]
+     [set :as python.set]
+     [frozenset :as python.frozenset]))
+  ```
+  (**Note**: this is done for you by the function `libpython-clj.require/import-python`)
+  
+  
+
 ## 1.32
 * DecRef now happens cooperatively in python thread.  We used to use separate threads
   in order to do decrement the refcount on objects that aren't reachable any more.  Now

--- a/src/libpython_clj/require.clj
+++ b/src/libpython_clj/require.clj
@@ -262,7 +262,6 @@
 
    (require-python '[operators :refer :*])"
   ([req]
-   ;; TODO -- change documentation
    (cond
      (list? req) ;; prefix list
      (let [prefix-lists (req-transform req)]
@@ -272,11 +271,14 @@
      (vector? req)
      (do-require-python req)
      :else
-     (throw (Exception. "Invalid argument: %s" req))))
+     (throw (Exception. "Invalid argument: %s" req)))
+   :ok)
   ([req & reqs]
    (require-python req)
    (when (not-empty reqs)
-     (apply require-python reqs))))
+     (apply require-python reqs))
+   :ok))
+
 
 (defn import-python
   "Loads python, python.list, python.dict, python.set, python.tuple,

--- a/src/libpython_clj/require.clj
+++ b/src/libpython_clj/require.clj
@@ -149,7 +149,7 @@
   ([prefix req] 
    (cond
      (and  (symbol? req)
-           (some #{\.} (into [] (str req))))
+           (clojure.string/includes? (name req) ".") )
      (throw (Exception.
              (str "After removing prefix list, requirements cannot "
                   "contain periods. Please remove periods from " req)))

--- a/src/libpython_clj/require.clj
+++ b/src/libpython_clj/require.clj
@@ -139,6 +139,37 @@
       (alias alias-name module-name))))
 
 
+(defn ^:private req-transform
+  ([req]
+   (if (symbol? req)
+     req
+     (let [base (first req)
+           reqs (rest req)]
+       (map (partial req-transform base) reqs))))
+  ([prefix req] 
+   (cond
+     (and  (symbol? req)
+           (some #{\.} (into [] (str req))))
+     (throw (Exception.
+             (str "After removing prefix list, requirements cannot "
+                  "contain periods. Please remove periods from " req)))
+     (symbol? req)
+     (symbol (str prefix "." req))
+     :else
+     (let [base   (first req)
+           reqs   (rest req)
+           alias? (reduce (fn [res [a b]]
+                            (cond
+                              (not b)   nil
+                              (= :as a) (reduced b)
+                              :else     nil))
+                          nil
+                          (partition 2 1 reqs))]
+       (if alias?
+         (into [(symbol (str prefix "." base))] reqs)
+         (into [(req-transform prefix base)] reqs))))))
+
+
 (defn require-python
   "## Basic usage ##
 
@@ -148,12 +179,13 @@
    (require-python '[math :as maaaath])
 
    (maaaath/sin 1.0) ;;=> 0.8414709848078965
-
-   (require-python '(math csv))
-   (require-python '([math :as pymath] csv))
-   (require-python '([math :as pymath] [csv :as py-csv])
+  
+   (require-python 'math 'csv)
+   (require-python '[math :as pymath] 'csv))
+   (require-python '[math :as pymath] '[csv :as py-csv])
    (require-python 'concurrent.futures)
    (require-python '[concurrent.futures :as fs])
+   (require-python '(concurrent [futures :as fs]))
 
    (require-python '[requests :refer [get post]])
 
@@ -201,6 +233,22 @@
    (os/chdir \"/path/to/foodir\")
 
 
+   ## prefix lists ##
+
+   For convenience, if you are loading multiple Python modules
+   with the same prefix, you can use the following notation:
+
+   (require-python '(a b c))
+   is equivalent to
+   (require-python 'a.b 'a.c)
+
+   (require-python '(foo [bar :as baz :refer [qux]]))
+   is equivalent to
+   (require-python '[foo.bar :as baz :refer [qux]])
+
+   (require-python '(foo [bar :as baz :refer [qux]] buster))
+   (require-python '[foo.bar :as baz :refer [qux]] 'foo.buster))
+  
    ## For library developers ##
 
    If you want to intern all symbols to your current namespace,
@@ -213,27 +261,34 @@
    you can do
 
    (require-python '[operators :refer :*])"
-  [reqs]
-
-  (cond
-    (list? reqs)
-    (doseq [req reqs] (require-python req))
-    (symbol? reqs)
-    (require-python (vector reqs))
-    (vector? reqs)
-    (do-require-python reqs)
-    :else
-    (throw (Exception. "Invalid argument: %s" reqs))))
+  ([req]
+   ;; TODO -- change documentation
+   (cond
+     (list? req) ;; prefix list
+     (let [prefix-lists (req-transform req)]
+       (doseq [req prefix-lists] (require-python req)))
+     (symbol? req) 
+     (require-python (vector req))
+     (vector? req)
+     (do-require-python req)
+     :else
+     (throw (Exception. "Invalid argument: %s" req))))
+  ([req & reqs]
+   (require-python req)
+   (when (not-empty reqs)
+     (apply require-python reqs))))
 
 (defn import-python
   "Loads python, python.list, python.dict, python.set, python.tuple,
   and python.frozenset."
   []
   (require-python
-   '([builtins :as python]
-     [builtins.list :as python.list]
-     [builtins.dict :as python.dict]
-     [builtins.set :as python.set]
-     [builtins.tuple :as python.tuple]
-     [builtins.frozenset :as python.frozenset])))
+   '(builtins
+     [list :as python.list]
+     [dict :as python.dict]
+     [set :as python.set]
+     [tuple :as python.tuple]
+     [frozenset :as python.frozenset])
+   '[builtins :as python])
+  :ok)
 

--- a/test/libpython_clj/require_python_test.clj
+++ b/test/libpython_clj/require_python_test.clj
@@ -2,8 +2,7 @@
   (:require [libpython-clj.require :as req :refer [require-python]
              :reload true]
             [libpython-clj.python :as py]
-            [clojure.test :refer :all]
-            [clojure.core.async :as a]))
+            [clojure.test :refer :all]))
 
 ;; Since this test mutates the global environment we have to accept that
 ;; it may not always work.


### PR DESCRIPTION
Closes: https://github.com/cnuernber/libpython-clj/issues/60

New `require-python` syntax: 

`(require-python '(a b c))` NOW implies `(require-python 'a.b 'a.c)` which implies 
```clojure 
(do
  (require-python 'a.b)
  (require-python 'a.c))
```
This also extends to requirement vectors.

`(require-python '(a [b :as c :refer [d] :someFlag]))` now implies 
`(require-python '[a.b :as c :refer [d] :someFlag])`


     