### PR TITLE
Fix Issue #43: non-reentrant with-gil causes deadlocks with pytorch

### DIFF
--- a/java/libpython_clj/jna/DirectMapped.java
+++ b/java/libpython_clj/jna/DirectMapped.java
@@ -10,6 +10,8 @@ public class DirectMapped
 {
   public static native void Py_IncRef(Pointer ptr);
   public static native void Py_DecRef(Pointer ptr);
+  public static native int PyGILState_Ensure();
+  public static native void PyGILState_Release(int gilState);
   public static native int PyGILState_Check();
   public static native void PyEval_RestoreThread(Pointer tstate);
   public static native Pointer PyEval_SaveThread();

--- a/src/libpython_clj/jna.clj
+++ b/src/libpython_clj/jna.clj
@@ -49,6 +49,8 @@
                 Py_None
                 Py_NotImplemented
                 PyMem_Free
+                PyGILState_Ensure
+                PyGILState_Release
                 PyGILState_Check
                 PyEval_RestoreThread
                 PyEval_SaveThread

--- a/src/libpython_clj/jna/interpreter.clj
+++ b/src/libpython_clj/jna/interpreter.clj
@@ -263,6 +263,35 @@
   [data-ptr jna/as-ptr])
 
 
+(defn PyGILState_Ensure
+  "Ensure that the current thread is ready to call the Python C API regardless of
+   the current state of Python, or of the global interpreter lock. This may be called
+   as many times as desired by a thread as long as each call is matched with a call
+   to PyGILState_Release(). In general, other thread-related APIs may be used between
+   PyGILState_Ensure() and PyGILState_Release() calls as long as the thread state is
+   restored to its previous state before the Release(). For example, normal usage of
+   the Py_BEGIN_ALLOW_THREADS and Py_END_ALLOW_THREADS macros is acceptable.
+
+   The return value is an opaque “handle” to the thread state when PyGILState_Ensure()
+   was called, and must be passed to PyGILState_Release() to ensure Python is left in 
+   the same state. Even though recursive calls are allowed, these handles cannot be shared -
+   each unique call to PyGILState_Ensure() must save the handle for its call to PyGILState_Release().
+
+   When the function returns, the current thread will hold the GIL and be able to call
+   arbitrary Python code. Failure is a fatal error."
+  ^long []
+  (DirectMapped/PyGILState_Ensure))
+
+(defn PyGILState_Release
+  "Release any resources previously acquired. After this call, Python’s state will be
+   the same as it was prior to the corresponding PyGILState_Ensure() call (but generally
+   this state will be unknown to the caller, hence the use of the GILState API).
+
+   Every call to PyGILState_Ensure() must be matched by a call to PyGILState_Release()
+   on the same thread."
+  [^long s]
+  (DirectMapped/PyGILState_Release s))
+
 (defn PyGILState_Check
   "Return 1 if the current thread is holding the GIL and 0 otherwise. This function
   can be called from any thread at any time. Only if it has had its Python thread

--- a/src/libpython_clj/python/bridge.clj
+++ b/src/libpython_clj/python/bridge.clj
@@ -667,7 +667,7 @@
   "Given a generic pyobject, wrap it in a read-only map interface
   where the keys are the attributes."
   [pyobj]
-  (with-gil nil
+  (with-gil
     (if (= :none-type (python-type pyobj))
       nil
       (let [interpreter (ensure-bound-interpreter)]


### PR DESCRIPTION
Further research python c api  (esp. https://docs.python.org/3/c-api/init.html#non-python-created-threads), base on torch developers who point out that PyGILState_Ensure and PyGILState_Release are reentrant (ie. recursive calls are allowed). 
  
* Change with-gil (acquire-gil! and release-gil!) to reentrant PyGILState api.
* Remove unnecessary acquire-gil! from interpreter/finalize!
* Remove unnecessary nil from with-wil in (defn generic-python-as-jvm)
* lein test passes

I've been using the patch in a nrepl session that runs for 6 hours with multiple clients (vscode calva remote ssh, and emacs cider-connect). All interactive evals are very responsive, no deadlocks. It used to deadlock within a few tools.namespace/refresh-all calls. 

