### PR TITLE
make release-gil! exception safe

### DIFF
--- a/src/libpython_clj/python/interpreter.clj
+++ b/src/libpython_clj/python/interpreter.clj
@@ -268,14 +268,14 @@ print(json.dumps(
 
 
 (defn release-gil!
-  "Reentrant pathway to release the gil.  It must not be held by this thread."
-  [git-state]
-  (libpy-base/set-gil-thread-id! (libpy-base/current-thread-id) Long/MAX_VALUE)
-  (libpy/PyGILState_Release git-state))
+  "Reentrant pathway to release the gil."
+  [gil-state]
+  (libpy/PyGILState_Release gil-state)
+  (libpy-base/set-gil-thread-id! (libpy-base/current-thread-id) Long/MAX_VALUE))
 
 
 (defn acquire-gil!
-  "Reentrant pathway to acquire gil.  It must not be held by this thread."
+  "Reentrant pathway to acquire gil."
   []
   (libpy-base/set-gil-thread-id! Long/MAX_VALUE (libpy-base/current-thread-id))
   (libpy/PyGILState_Ensure))


### PR DESCRIPTION
Since set-gil-thread-id! throws if CAS fails, this patch makes release-gil! exception safe by moving native call before it.

I only had one set-gil-thread-id! throwing CAS failure, so might not be worth it to spin on CAS failure, but at least shouldn't leave GIL in the bad state.