### PR TITLE
Added support for anaconda python under windows

### DIFF
--- a/docs/Usage.md
+++ b/docs/Usage.md
@@ -44,7 +44,7 @@ user> (require '[libpython-clj.python
                          python-type]])
 nil
 
-
+; Mac and Linux
 user> (initialize!)
 Jun 30, 2019 4:47:39 PM clojure.tools.logging$eval7369$fn__7372 invoke
 INFO: executing python initialize!
@@ -52,6 +52,17 @@ Jun 30, 2019 4:47:39 PM clojure.tools.logging$eval7369$fn__7372 invoke
 INFO: Library python3.6m found at [:system "python3.6m"]
 Jun 30, 2019 4:47:39 PM clojure.tools.logging$eval7369$fn__7372 invoke
 INFO: Reference thread starting
+:ok
+
+; Windows with Anaconda
+(initialize! ; Python executable
+             :python-executable "C:\\Users\\USER\\AppData\\Local\\Continuum\\anaconda3\\python.exe"
+             ; Python Library
+             :library-path "C:\\Users\\USER\\AppData\\Local\\Continuum\\anaconda3\\python37.dll"
+             ; Anacondas PATH environment to load native dlls of modules (numpy, etc.)
+             :windows-anaconda-activate-bat "C:\\Users\\USER\\AppData\\Local\\Continuum\\anaconda3\\Scripts\\activate.bat"
+             )
+...
 :ok
 ```
 

--- a/src/libpython_clj/python.clj
+++ b/src/libpython_clj/python.clj
@@ -4,6 +4,7 @@
             [libpython-clj.python.interpreter :as pyinterp]
             [libpython-clj.python.object :as pyobj]
             [libpython-clj.python.bridge :as pybridge]
+            [libpython-clj.python.windows :as win]
             [libpython-clj.jna :as libpy]
             ;;Protocol implementations purely for nd-ness
             [libpython-clj.python.np-array]
@@ -235,7 +236,8 @@
              library-path
              python-home
              no-io-redirect?
-             python-executable]}]
+             python-executable
+             windows-anaconda-activate-bat]}]
   (when-not @pyinterp/main-interpreter*
     (pyinterp/initialize! :program-name program-name
                           :library-path library-path
@@ -245,14 +247,16 @@
     (pyinterop/register-bridge-type!)
     (when-not no-io-redirect?
       (pyinterop/setup-std-writer #'*err* "stderr")
-      (pyinterop/setup-std-writer #'*out* "stdout")))
+      (pyinterop/setup-std-writer #'*out* "stdout"))
+    (if-not (nil? windows-anaconda-activate-bat)
+      (win/setup-windows-conda! windows-anaconda-activate-bat)))
   :ok)
 
 
 (defn ptr-refcnt
   [item]
   (-> (libpy/as-pyobj item)
-      (libpython_clj.jna.PyObject. )
+      (libpython_clj.jna.PyObject.)
       (.ob_refcnt)))
 
 

--- a/src/libpython_clj/python/interpreter.clj
+++ b/src/libpython_clj/python/interpreter.clj
@@ -1,5 +1,5 @@
 (ns libpython-clj.python.interpreter
-  (:require [libpython-clj.jna :as libpy ]
+  (:require [libpython-clj.jna :as libpy]
             [libpython-clj.jna.base :as libpy-base]
             [libpython-clj.python.gc :as pygc]
             [libpython-clj.python.logging
@@ -30,13 +30,13 @@
   (let [{:keys [out err exit]}
         (sh executable "-c" "import sys, json;
 print(json.dumps(
-{\"platform\":          sys.platform,
-  \"prefix\":           sys.prefix,
-  \"base_prefix\":      sys.base_prefix,
-  \"executable\":       sys.executable,
-  \"base_exec_prefix\": sys.base_exec_prefix,
-  \"exec_prefix\":      sys.exec_prefix,
-  \"version\":          list(sys.version_info)[:3]}))")]
+{'platform':          sys.platform,
+  'prefix':           sys.prefix,
+  'base_prefix':      sys.base_prefix,
+  'executable':       sys.executable,
+  'base_exec_prefix': sys.base_exec_prefix,
+  'exec_prefix':      sys.exec_prefix,
+  'version':          list(sys.version_info)[:3]}))")]
     (when (= 0 exit)
       (json/read-str out :key-fn keyword))))
 
@@ -93,7 +93,7 @@ print(json.dumps(
         ;;   ..: mac and windows are for sys.platform
         :linux   "libpython%s.%sm.so$"
         :mac     "libpython%s.%sm.dylib$"
-        :windows "python%s.%sm.dll$")
+        :win32   "python%s%s.dll$")
       major minor))))
 
 (defn python-library-paths
@@ -131,9 +131,9 @@ print(json.dumps(
   (let [executable "python3.7"
         system-info (python-system-info executable)
         pyregex (python-library-regex system-info)]
-    (python-library-paths system-info pyregex))
+    (python-library-paths system-info pyregex)))
   ;;=> ["/usr/lib/x86_64-linux-gnu/libpython3.7m.so" "/usr/lib/python3.7/config-3.7m-x86_64-linux-gnu/libpython3.7m.so"]
-  )
+
 
 (defn- ignore-shell-errors
   [& args]
@@ -179,8 +179,8 @@ print(json.dumps(
 ;;get the type of that item if we have seen it before.
 (defrecord Interpreter [
                         interpreter-state* ;;Thread state, per interpreter
-                        shared-state* ;;state shared among all interpreters
-                        ])
+                        shared-state*]) ;;state shared among all interpreters
+
 
 
 ;; Main interpreter booted up during initialize!
@@ -411,7 +411,7 @@ print(json.dumps(
              python-executable]
       :as options}]
   (when-not (main-interpreter)
-    (log-info (str "Executing python initialize with options:" options) )
+    (log-info (str "Executing python initialize with options:" options))
     (let [{:keys [python-home libname java-library-path-addendum] :as startup-info}
           (detect-startup-info options)
           library-names (cond

--- a/src/libpython_clj/python/windows.clj
+++ b/src/libpython_clj/python/windows.clj
@@ -1,0 +1,43 @@
+(ns libpython-clj.python.windows
+  (:require [libpython-clj.python.interop :refer [run-simple-string]]
+            [clojure.java.shell :refer [sh]]
+            [clojure.java.io :as io]
+            [clojure.string :as s]))
+
+(defn create-echo-path-bat! []
+  "Creates temporary file to extract condas PATH environment variable"
+  (let [tmp (java.io.File/createTempFile "echo-path" ".bat")]
+    (spit tmp "echo %PATH%")
+    (.toString tmp)))
+
+(defn delete-echo-path-bat! [tmp]
+  "Deletes temporary file"
+  (io/delete-file tmp))
+
+(defn- get-windows-anaconda-env-path [activate-bat echo-bat]
+  "Get anacondas windows PATH environment variable to load native dlls for numpy etc. like python with anaconda does."
+  (-> (sh "cmd.exe" "/K" (str activate-bat " & " echo-bat))
+      :out
+      (s/split #"\r\n")
+      reverse
+      (nth 2)))
+
+
+(defn- generate-python-set-env-path [path]
+  "Double quote windows path separator \\ -> \\\\"
+  (let [quoted (s/replace path "\\" "\\\\")]
+    (str
+      "import os;\n"
+      "path = '" quoted "';\n"
+      "os.environ['PATH'] = path;\n")))
+
+(defn setup-windows-conda! [windows-conda-activate-bat]
+  "Setup python PATH environment variable like in anaconda to be able to load native dlls for numpy etc. like anaconda does."
+  (let [echo-bat (create-echo-path-bat!)]
+    (->> (get-windows-anaconda-env-path
+           windows-conda-activate-bat
+           echo-bat)
+         generate-python-set-env-path
+         run-simple-string)
+    (delete-echo-path-bat! echo-bat)))
+


### PR DESCRIPTION
Allows to use libpython-clj in windows with anacondas python environment. 
Major challange was to be able to load native windows dlls for python modules. Therefore the PATH environment of anaconda had to be extracted and then loaded inside libpython-clj PATH environment variable, so that libpython-clj could find the right windows dlls on the PATH for its python modules (numpy etc.).
Requires a little bit manual setup for (initialize! ...). Documentation added.