### PR TITLE
allow nil ns-prefix in codegen/write-namespace!

### DIFF
--- a/src/libpython_clj2/codegen.clj
+++ b/src/libpython_clj2/codegen.clj
@@ -151,7 +151,9 @@ user> (doto (python/list)
                         exclude default-exclude}}]
    (let [metadata-fn (requiring-resolve
                       'libpython-clj2.metadata/datafy-module-or-class)
-         ns-symbol (or ns-symbol (symbol (str ns-prefix "." py-mod-or-cls)))]
+         ns-symbol (or ns-symbol (symbol (str (when-not (s/blank? ns-prefix)
+                                                (str ns-prefix "."))
+                                              py-mod-or-cls)))]
      (py/with-gil-stack-rc-context
        (let [target (py/path->py-obj py-mod-or-cls)
              target-metadata (metadata-fn target)

--- a/test/libpython_clj2/codegen_test.clj
+++ b/test/libpython_clj2/codegen_test.clj
@@ -1,0 +1,37 @@
+(ns libpython-clj2.codegen-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.string :as s]
+            [clojure.java.io :as io]
+            [libpython-clj2.codegen :as codegen]))
+
+(defn- ns-symbol-for
+  [py-mod-or-cls ns-prefix]
+  (symbol (str (when-not (s/blank? ns-prefix)
+                 (str ns-prefix "."))
+               py-mod-or-cls)))
+
+(deftest ns-prefix-nil-test
+  (testing "ns-prefix nil should not produce leading dot"
+    (is (= 'numpy (ns-symbol-for "numpy" nil)))
+    (is (= 'builtins (ns-symbol-for "builtins" nil))))
+
+  (testing "ns-prefix empty string should not produce leading dot"
+    (is (= 'numpy (ns-symbol-for "numpy" "")))
+    (is (= 'builtins (ns-symbol-for "builtins" ""))))
+
+  (testing "ns-prefix with value should produce prefixed namespace"
+    (is (= 'python.numpy (ns-symbol-for "numpy" "python")))
+    (is (= 'my.prefix.builtins (ns-symbol-for "builtins" "my.prefix")))))
+
+(deftest write-namespace-nil-prefix-test
+  (testing "write-namespace! with nil ns-prefix"
+    (let [tmp-dir (str (System/getProperty "java.io.tmpdir") "/libpython-clj-test-" (System/currentTimeMillis))]
+      (try
+        (codegen/write-namespace! "builtins" {:output-dir tmp-dir
+                                              :ns-prefix nil})
+        (is (.exists (io/file tmp-dir "builtins.clj")))
+        (let [content (slurp (io/file tmp-dir "builtins.clj"))]
+          (is (re-find #"\(ns builtins" content)))
+        (finally
+          (doseq [f (reverse (file-seq (io/file tmp-dir)))]
+            (.delete f)))))))


### PR DESCRIPTION
Closes #211

Allow `nil` or blank `:ns-prefix` in `codegen/write-namespace!`.

Previously, using a `nil` `:ns-prefix` resulted in a namespace starting with `.` (e.g., `.numpy`), which is an illegal Java class name.

## Changes

- Modified `write-namespace!` to skip the prefix and dot when `:ns-prefix` is nil or blank
- Added tests for the ns-prefix behavior

## Example

```clojure
;; Before: (write-namespace! "numpy" {:ns-prefix nil})
;; => generates namespace ".numpy" (invalid)

;; After: (write-namespace! "numpy" {:ns-prefix nil})
;; => generates namespace "numpy" (valid)
```
